### PR TITLE
Docs: README.md에 회의록 링크 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,34 @@
 # MandarinOrangeMarket
+
 멋쟁이사자처럼 프로젝트 12조 감귤마켓 레포지토리입니다.
 
-## 1. 팀원
+## 회의록 링크(임시)
 
-| 이지형   | 이재영 | 정수현 |
-| :-------: |:-------:|:-------:|
-| <img src="https://avatars.githubusercontent.com/u/90930391?v=4" height=180 width=180>| <img src="https://avatars.githubusercontent.com/u/103429329?v=4" height=180 width=180>| <img src="https://avatars.githubusercontent.com/u/68059880?v=4" height=180 width=180>|
-|<a href="https://github.com/July249"><img src="https://img.shields.io/badge/GitHub-181717?style=flat&logo=GitHub&logoColor=white"/></a> |<a href="https://github.com/GreattitJY"><img src="https://img.shields.io/badge/GitHub-181717?style=flat&logo=GitHub&logoColor=white"/></a> |<a href="https://github.com/IntHyun"><img src="https://img.shields.io/badge/GitHub-181717?style=flat&logo=GitHub&logoColor=white"/></a>|
+- [회의록](https://github.com/beyondDevelops/MandarinOrangeMarket/wiki)
 
-## 2. 커밋 컨벤션
+<br>
+
+## 커밋 컨벤션
 
 | 키워드   | 사용 시점                              |
 | :------- | :------------------------------------- |
 | Feat     | 새로운 기능 추가                       |
 | Fix      | 버그 수정                              |
 | Docs     | 문서 수정                              |
-| Style    | 세미콜론 누락 등 기능 수정이 없는 경우  |
+| Style    | 세미콜론 누락 등 기능 수정이 없는 경우 |
 | Design   | 사용자 UI 디자인 변경 (CSS 등)         |
-| Test     | 테스트 코드, 리팩토링 테스트 코드 추가  |
+| Test     | 테스트 코드, 리팩토링 테스트 코드 추가 |
 | Refactor | 코드 리팩토링                          |
 | Build    | 빌드 파일 수정                         |
-| Setting  | 패키지 매니저 수정, 개발 환경 설정 등   |
-| Rename   | 파일 혹은 폴더명을 수정만 한 경우       |
+| Setting  | 패키지 매니저 수정, 개발 환경 설정 등  |
+| Rename   | 파일 혹은 폴더명을 수정만 한 경우      |
 | Remove   | 파일을 삭제한 경우                     |
+
+<br>
+
+## 팀원
+
+|                                                                 이지형                                                                  |                                                                   이재영                                                                   |                                                                 정수현                                                                  |
+| :-------------------------------------------------------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------: |
+|                          <img src="https://avatars.githubusercontent.com/u/90930391?v=4" height=150 width=150>                          |                           <img src="https://avatars.githubusercontent.com/u/103429329?v=4" height=150 width=150>                           |                          <img src="https://avatars.githubusercontent.com/u/68059880?v=4" height=150 width=150>                          |
+| <a href="https://github.com/July249"><img src="https://img.shields.io/badge/GitHub-181717?style=flat&logo=GitHub&logoColor=white"/></a> | <a href="https://github.com/GreattitJY"><img src="https://img.shields.io/badge/GitHub-181717?style=flat&logo=GitHub&logoColor=white"/></a> | <a href="https://github.com/IntHyun"><img src="https://img.shields.io/badge/GitHub-181717?style=flat&logo=GitHub&logoColor=white"/></a> |


### PR DESCRIPTION
README.md 파일에 임시로 회의록 링크를 추가했습니다. 

매번 깃허브에서 wiki를 파고 들어가는 게 불편해서 맨 위에 임시로 올려두었습니다.